### PR TITLE
Update __init__.py

### DIFF
--- a/src/wagtail_tag_manager/__init__.py
+++ b/src/wagtail_tag_manager/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = "wagtail_tag_manager.config.WagtailTagManagerConfig"
+try:
+    import django
+except ImportError:
+    # setup.py and docs do not have Django installed.
+    django = None
+
+if django and django.VERSION < (3, 2):
+    default_app_config = "wagtail_tag_manager.config.WagtailTagManagerConfig"


### PR DESCRIPTION
make compatible with django 4.1

without this Django 4.1 and above will raise a deprecation warning as the "default_app_config" mechanism has now been removed